### PR TITLE
add source-map-support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
     "module-alias": "^2.2.2",
     "prettier": "^2.4.1",
+    "source-map-support": "^0.5.21",
     "tsc-watch": "^4.5.0",
     "typescript": "^4.5.2"
   },

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import 'reflect-metadata'
+import 'source-map-support/register'
 // Setup @/ aliases for modules
 import 'module-alias/register'
 // Config dotenv

--- a/yarn.lock
+++ b/yarn.lock
@@ -412,6 +412,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer-from@npm:^1.0.0":
+  version: 1.1.2
+  resolution: "buffer-from@npm:1.1.2"
+  checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
+  languageName: node
+  linkType: hard
+
 "buffer@npm:^5.6.0":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
@@ -1951,6 +1958,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-support@npm:^0.5.21":
+  version: 0.5.21
+  resolution: "source-map-support@npm:0.5.21"
+  dependencies:
+    buffer-from: ^1.0.0
+    source-map: ^0.6.0
+  checksum: 43e98d700d79af1d36f859bdb7318e601dfc918c7ba2e98456118ebc4c4872b327773e5a1df09b0524e9e5063bb18f0934538eace60cca2710d1fa687645d137
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.6.0":
+  version: 0.6.1
+  resolution: "source-map@npm:0.6.1"
+  checksum: 59ce8640cf3f3124f64ac289012c2b8bd377c238e316fb323ea22fbfe83da07d81e000071d7242cad7a23cd91c7de98e4df8830ec3f133cb6133a5f6e9f67bc2
+  languageName: node
+  linkType: hard
+
 "sparse-bitfield@npm:^3.0.3":
   version: 3.0.3
   resolution: "sparse-bitfield@npm:3.0.3"
@@ -2060,6 +2084,7 @@ __metadata:
     mongoose: ^6.0.13
     mongoose-findorcreate: ^3.0.0
     prettier: ^2.4.1
+    source-map-support: ^0.5.21
     tsc-watch: ^4.5.0
     typescript: ^4.5.2
   languageName: unknown


### PR DESCRIPTION
This module provides source map support for stack traces in node via the V8 stack trace API. It uses the source-map module to replace the paths and line numbers of source-mapped files with their original paths and line numbers
